### PR TITLE
Nova organização: DevIsland

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Badge | Link | Participar
 - | [grupy-rp]() | [Participar](https://grupyrp.herokuapp.com)
 ![Participantes](http://slack.minasdev.org/badge.svg) | Minas Dev | [Participar](http://slack.minasdev.org/) 
 ![Participantes](http://pbjs-slack.herokuapp.com/badge.svg) | ParaibaJS | [Participar](http://pbjs-slack.herokuapp.com/)
+- | DevIsland | [Participar](https://devisland.stamplayapp.com/)
 
 ## Infraestrutura de TI
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Badge | Link | Participar
 - | [grupy-rp]() | [Participar](https://grupyrp.herokuapp.com)
 ![Participantes](http://slack.minasdev.org/badge.svg) | Minas Dev | [Participar](http://slack.minasdev.org/) 
 ![Participantes](http://pbjs-slack.herokuapp.com/badge.svg) | ParaibaJS | [Participar](http://pbjs-slack.herokuapp.com/)
-- | DevIsland | [Participar](https://devisland.stamplayapp.com/)
+- | [DevIsland](http://devisland.com/) | [Participar](https://devisland.stamplayapp.com/)
 
 ## Infraestrutura de TI
 


### PR DESCRIPTION
Essa comunidade entrega anualmente, em Belo Horizonte, um evento chamado DevDay, para 400-500 desenvolvedores. http://devday.devisland.com/